### PR TITLE
Add enum arrays to consts file

### DIFF
--- a/server/db/models/Dog.js
+++ b/server/db/models/Dog.js
@@ -10,7 +10,7 @@ const DogSchema = new Schema({
   },
   gender: {
     type: String,
-    enum: consts.genderArray,
+    enum: consts.genderPetArray,
     required: true,
   },
   breed: {
@@ -92,7 +92,7 @@ const DogSchema = new Schema({
         age: Number,
         gender: {
           type: String,
-          enum: consts.genderOtherArray,
+          enum: consts.genderPersonArray,
         },
         relationshipToPartner: {
           type: String,
@@ -108,7 +108,7 @@ const DogSchema = new Schema({
         age: Number,
         gender: {
           type: String,
-          enum: consts.genderArray,
+          enum: consts.genderPetArray,
         },
       },
     ],

--- a/server/db/models/Dog.js
+++ b/server/db/models/Dog.js
@@ -1,4 +1,5 @@
 import mongoose, { SchemaTypes } from "mongoose";
+import { consts } from "@/utils/consts";
 
 const { Schema } = mongoose;
 
@@ -9,7 +10,7 @@ const DogSchema = new Schema({
   },
   gender: {
     type: String,
-    enum: ["Female", "Male"],
+    enum: consts.genderArray,
     required: true,
   },
   breed: {
@@ -22,17 +23,17 @@ const DogSchema = new Schema({
   },
   behavior: {
     type: String,
-    enum: ["No concern", "Some concern", "High concern"],
+    enum: consts.concernArray,
     required: true,
   },
   medical: {
     type: String,
-    enum: ["No concern", "Some concern", "High concern"],
+    enum: consts.concernArray,
     required: true,
   },
   other: {
     type: String,
-    enum: ["No concern", "Some concern", "High concern"],
+    enum: consts.concernArray,
     required: true,
   },
   recentLogs: {
@@ -66,16 +67,16 @@ const DogSchema = new Schema({
   maternalDemeanor: {
     // order: [before, during, after] birth
     type: String,
-    enum: ["Happy", "Sad", "Fearful"], // placeholders
+    enum: consts.demeanorArray,
   },
   location: {
     type: String,
-    enum: ["Facility 1", "Facility 2", "Placed"],
+    enum: consts.locationArray,
     required: true,
   },
   rolePlacedAs: {
     type: String,
-    enum: ["Service", "Companion"],
+    enum: consts.roleArray,
   },
   partner: {
     type: SchemaTypes.ObjectId,
@@ -83,7 +84,7 @@ const DogSchema = new Schema({
   },
   toiletArea: {
     type: String,
-    enum: ["Leashed", "Off-leash"],
+    enum: consts.leashArray,
   },
   housemates: {
     type: [
@@ -91,11 +92,11 @@ const DogSchema = new Schema({
         age: Number,
         gender: {
           type: String,
-          enum: ["Female", "Male", "Other"],
+          enum: consts.genderOtherArray,
         },
         relationshipToPartner: {
           type: String,
-          enum: ["Sibling", "Parent", "Partner", "Friend", "Child", "Other"],
+          enum: consts.relationshipArray,
         },
       },
     ],
@@ -107,7 +108,7 @@ const DogSchema = new Schema({
         age: Number,
         gender: {
           type: String,
-          enum: ["Female", "Male"],
+          enum: consts.genderArray,
         },
       },
     ],

--- a/server/db/models/Log.js
+++ b/server/db/models/Log.js
@@ -14,8 +14,8 @@ const LogSchema = new Schema({
     required: true,
   },
   tags: {
-    // validate for these: "auditory", "heartworm", "fleas/ticks"
     type: [String],
+    enum: consts.tagsArray,
   },
   severity: {
     type: String,

--- a/server/db/models/Log.js
+++ b/server/db/models/Log.js
@@ -1,4 +1,5 @@
 import mongoose, { SchemaTypes } from "mongoose";
+import { consts } from "@/utils/consts";
 
 const { Schema } = mongoose;
 
@@ -9,7 +10,7 @@ const LogSchema = new Schema({
   },
   topic: {
     type: String,
-    enum: ["Medical", "Behavioral", "Other"],
+    enum: consts.topicArray,
     required: true,
   },
   tags: {
@@ -18,7 +19,7 @@ const LogSchema = new Schema({
   },
   severity: {
     type: String,
-    enum: ["No concern", "Some concern", "High concern"],
+    enum: consts.concernArray,
     required: true,
   },
   description: {

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -10,6 +10,23 @@ const pages = {
 
 const consts = {
   baseUrl: process.env.BASE_URL ?? "http://localhost:3000",
+
+  genderArray: ["Female", "Male"],
+  genderOtherArray: ["Female", "Male", "Other"],
+  concernArray: ["No concern", "Some concern", "High concern"],
+  demeanorArray: ["Happy", "Sad", "Fearful"], // placeholders
+  locationArray: ["Facility 1", "Facility 2", "Placed"],
+  roleArray: ["Service", "Companion"],
+  leashArray: ["Leashed", "Off-leash"],
+  relationshipArray: [
+    "Sibling",
+    "Parent",
+    "Partner",
+    "Friend",
+    "Child",
+    "Other",
+  ],
+  topicArray: ["Medical", "Behavioral", "Other"],
 };
 
 export { pages, consts };

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -11,8 +11,8 @@ const pages = {
 const consts = {
   baseUrl: process.env.BASE_URL ?? "http://localhost:3000",
 
-  genderArray: ["Female", "Male"],
-  genderOtherArray: ["Female", "Male", "Other"],
+  genderPetArray: ["Female", "Male"],
+  genderPersonArray: ["Female", "Male", "Other"],
   concernArray: ["No concern", "Some concern", "High concern"],
   demeanorArray: ["Happy", "Sad", "Fearful"], // placeholders
   locationArray: ["Facility 1", "Facility 2", "Placed"],
@@ -27,6 +27,7 @@ const consts = {
     "Other",
   ],
   topicArray: ["Medical", "Behavioral", "Other"],
+  tagsArray: ["auditory", "heartworm", "fleas/ticks"],
 };
 
 export { pages, consts };


### PR DESCRIPTION
## Add Enum Arrays to Consts File
The arrays for enums in the schema models for Dog and Log have been moved to the utils/consts file so that these constant string arrays can be used in multiple locations throughout the codebase, and every instance of these arrays can be updated at the same time if there are any changes.

### Checklist
- [x] Requirements have been implemented
- [x] Acceptance criteria is met
- [x] Database schema docs have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (EM) have been assigned to this PR