### PR TITLE
Fix Links For Recent Log Tags

### DIFF
--- a/src/components/DogTable.jsx
+++ b/src/components/DogTable.jsx
@@ -156,7 +156,7 @@ export default function DogTable() {
             {rowData.recentLogs.map((log) =>
               log.tags.map((tag, i) => (
                 <Chip
-                  link={rowData._id + "/" + log._id}
+                  link={"dogs/" + rowData._id + "?showLogTab=true&filteredTag=" + tag}
                   key={i}
                   label={tag}
                   type={ChipTypeStyles.Tag}

--- a/src/pages/dogs/[id].jsx
+++ b/src/pages/dogs/[id].jsx
@@ -1,9 +1,10 @@
 import TabSection from "@/components/TabSection";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import toast from "react-hot-toast";
 import { useRouter } from "next/router";
 import dateutils from "@/utils/dateutils";
+import stringUtils from "@/utils/stringutils";
 import {
   ChevronLeftIcon,
   PencilSquareIcon,
@@ -28,17 +29,24 @@ export default function IndividualDogPage() {
   const [data, setData] = useState();
   const [showLogModal, setShowLogModal] = useState(false);
 
-  const router = useRouter();
-
   const [searchQuery, setSearchQuery] = useState("");
   const [appliedFilters, setAppliedFilters] = useState({});
   const [logs, setLogs] = useState([]);
   const [filteredLogs, setFilteredLogs] = useState([]);
+  const [ showLogTab, setShowLogTab ] = useState(false);
+
+  const router = useRouter();
+  const logRef = useRef(null);
 
   let search = {};
   search.dog = router.query.id;
 
   useEffect(() => {
+    setShowLogTab(router.query?.showLogTab);
+    if (router.query?.filteredTag) {
+      setAppliedFilters({ tags: [ stringUtils.upperFirstLetter(router.query?.filteredTag) ]});
+    }
+
     if (router.query.id) {
       fetch(`/api/dogs/${router.query.id}`)
         .then((res) => res.json())
@@ -96,7 +104,11 @@ export default function IndividualDogPage() {
         })
       );
     }
-  }, [logs, appliedFilters, searchQuery]);
+
+    if (router.query?.showLogTab && logRef.current) {
+      window.scrollTo(0, logRef.current.offsetTop);
+    }
+  }, [ logs, appliedFilters, searchQuery, router.query, logRef.current ]);
 
   if (!data || data === undefined || !data.success) {
     return <div>loading</div>;
@@ -302,8 +314,8 @@ export default function IndividualDogPage() {
         )}
       </div>
 
-      <div className="mt-8 shadow-xl rounded-lg text-md w-full text-left relative bg-foreground p-8">
-        <TabSection defaultTab="information">
+      <div ref={logRef} className="mt-8 shadow-xl rounded-lg text-md w-full text-left relative bg-foreground p-8">
+        <TabSection defaultTab={showLogTab ? "logs" : "information"}>
           <div label="information">
             <div className="w-2/3 grid grid-cols-3 gap-16">
               {Object.keys(dogInformationSchema).map((category) => (


### PR DESCRIPTION
## Fix Links for Recent Log Tags
Issue Number(s): #65

For the [id] page, there have been more query parameters added including `showLogTab` which shows the log tab as the default tab when the page is opened, and `filteredTag` which allows for one tag to be filtered. An example of this link is `http://localhost:3000/dogs/65355ca0fa9f201f083aff37?showLogTab=true&filteredTag=auditory`. When the recent log tag is clicked from the Dog table, it goes to the corresponding link which shows the logs filtered with that log tag.

### Checklist
- [x] Requirements have been implemented
- [x] Acceptance criteria is met
- [x] Database schema [docs](https://www.notion.so/gtbitsofgood/Database-Schema-Docs-a841a38d02db4428a7cdc85dcbb8a35c?pvs=4) have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (EM) have been assigned to this PR