### PR TITLE
Fix Loading State for Invalid Dog

### DIFF
--- a/src/components/Form/Form.jsx
+++ b/src/components/Form/Form.jsx
@@ -18,6 +18,7 @@ import { consts } from "@/utils/consts";
 import { ChevronLeftIcon } from "@heroicons/react/24/solid";
 import { formActions, formMap } from "@/utils/formUtils";
 import dateutils from "@/utils/dateutils";
+import Custom404 from "@/pages/404";
 
 export default function Form({ mode }) {
   const [showCancelModal, setShowCancelModal] = useState(false);
@@ -58,8 +59,10 @@ export default function Form({ mode }) {
     }
   }, [ router ]);
 
-  if (!router.query || !dog || dog === undefined || !dog.success || (mode != formActions.NEW && (!router.query || !formData || formData == undefined))) {
+  if (!router.query || !dog || dog === undefined || (mode != formActions.NEW && (!router.query || !formData || formData == undefined))) {
     return <div>loading</div>;
+  } else if (!dog.success) {
+    return <Custom404 />;
   }
 
   const formType = formMap[router.query.type]

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import { ChevronLeftIcon } from "@heroicons/react/24/solid";
+
+export default function Custom404() {
+  return (
+    <>
+      <div className="py-6 flex items-center">
+        <ChevronLeftIcon className="w-4 mr-2" />
+        <Link href="/dogs" className="text-lg text-secondary-text">
+          Return to dashboard
+        </Link>
+      </div>
+      <div className="flex flex-col items-center justify-center self-center text-center m-10">
+        <div className="font-semibold text-5xl mb-4">404</div>
+        <div className="text-2xl">This page does not exist!</div>
+      </div>
+    </>
+  );
+}

--- a/src/pages/500.js
+++ b/src/pages/500.js
@@ -1,0 +1,10 @@
+export default function Custom500() {
+  return (
+    <div className="flex flex-col items-center justify-center self-center text-center m-10">
+      <div className="font-semibold text-5xl mb-4">500</div>
+      <div className="text-2xl">
+        There has been an error! Reload the page and try again
+      </div>
+    </div>
+  );
+}

--- a/src/pages/dogs/[id]/index.jsx
+++ b/src/pages/dogs/[id]/index.jsx
@@ -27,6 +27,7 @@ import LoadingAnimation from "@/components/LoadingAnimation";
 import { formTitleMap } from "@/utils/formUtils";
 import DogEditingLayout from "@/layouts/DogEditingLayout";
 import Layout from "@/layouts/Layout";
+import Custom404 from "@/pages/404";
 
 /**
  *
@@ -134,7 +135,7 @@ export default function IndividualDogPage() {
   }, [logs, appliedFilters, searchQuery, router.query, logRef.current]);
 
   useEffect(() => {
-    if (data) {
+    if (data && data.success) {
       fetch("/api/forms/search", {
         method: "POST",
         headers: {
@@ -150,8 +151,10 @@ export default function IndividualDogPage() {
     }
   }, [data]);
 
-  if (!data || !data.success) {
+  if (!data) {
     return <LoadingAnimation />;
+  } else if (!data.success) {
+    return <Custom404 />
   }
 
   const dog = data.data;


### PR DESCRIPTION
## Fix Loading State for Invalid Dog
Issue Number(s): #60

When the user goes to an invalid dog link like `http://localhost:3000/dogs/1234`, there is now a message that says if the dog does not exist rather than being stuck in the loading state.

### Checklist
- [x] Requirements have been implemented
- [x] Acceptance criteria is met
- [x] Database schema [docs](https://www.notion.so/gtbitsofgood/Database-Schema-Docs-a841a38d02db4428a7cdc85dcbb8a35c?pvs=4) have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (EM) have been assigned to this PR