### PR TITLE
Move Add Log Button and Disable Save Log Button

### DIFF
--- a/src/components/LogModal.jsx
+++ b/src/components/LogModal.jsx
@@ -28,6 +28,7 @@ export default function LogModal({ dogId, userId, onClose, onSubmit }) {
     description: false
   });
 
+  const [ saving, setSaving ] = useState(false);
   const modalRef = useRef(null);
 
   useEffect(() => {
@@ -56,6 +57,7 @@ export default function LogModal({ dogId, userId, onClose, onSubmit }) {
     const { success, error, data } = logSchema.safeParse(formattedData);
 
     if (success) {
+      setSaving(true);
       fetch("/api/logs", {
         method: "POST",
         headers: {
@@ -66,8 +68,10 @@ export default function LogModal({ dogId, userId, onClose, onSubmit }) {
       .then((res) => {
         onSubmit(true);
         onClose();
+        setSaving(false);
       })
       .catch((err) => {
+        setSaving(false);
         onSubmit(false);
       });
     } else {
@@ -270,8 +274,8 @@ export default function LogModal({ dogId, userId, onClose, onSubmit }) {
               Cancel
             </div>
           </button>
-          <button onClick={() => saveLog(logData)} className="w-full sm:w-32 h-10 px-4 py-2.5 bg-ca-pink rounded border border-ca-pink-shade justify-center items-center gap-2 flex">
-            <div className="text-foreground text-base font-medium">
+          <button onClick={() => saveLog(logData)} disabled={saving} className={`w-full sm:w-32 h-10 px-4 py-2.5 ${saving ? " bg-primary-gray border-tertiary-gray " : " bg-ca-pink border-ca-pink-shade "}  rounded border justify-center items-center gap-2 flex`}>
+            <div className={`${saving ? "text-tertiary-gray " : "text-foreground "} text-base font-medium`}>
               Save
             </div>
           </button>

--- a/src/components/LogSearchFilterBar.jsx
+++ b/src/components/LogSearchFilterBar.jsx
@@ -1,8 +1,8 @@
-import { MagnifyingGlassIcon } from "@heroicons/react/24/solid";
+import { MagnifyingGlassIcon, PlusIcon } from "@heroicons/react/24/solid";
 import DropdownMenu, { DropdownMenuOption } from "./DropdownMenu";
 import { consts } from "@/utils/consts";
 
-export default function LogSearchFilterBar({ filters, setFilters, setSearch }) {
+export default function LogSearchFilterBar({ filters, setFilters, setSearch, addLogFunction }) {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-row justify-between">
@@ -18,10 +18,10 @@ export default function LogSearchFilterBar({ filters, setFilters, setSearch }) {
             onChange={(e) => setSearch(e.target.value)}
           />
         </div>
-        {/* <button className=" px-4 py-2.5 bg-ca-pink rounded border border-ca-pink-shade justify-start items-center gap-2 flex">
+        <button onClick={() => addLogFunction()} className=" px-4 py-2.5 bg-ca-pink rounded border border-ca-pink-shade justify-start items-center gap-2 flex">
           <div className="text-foreground h-4 w-4 relative">{<PlusIcon />}</div>
           <div className="text-foreground text-base font-medium">Add a log</div>
-        </button> */}
+        </button>
       </div>
       <div className="flex flex-row items-center gap-4">
         <div className="text-neutral-700 text-sm font-medium">Filter by</div>

--- a/src/pages/dogs/[id].jsx
+++ b/src/pages/dogs/[id].jsx
@@ -325,21 +325,11 @@ export default function IndividualDogPage() {
           </div>
           <div label="logs">
             <div className="flex-grow flex-col space-y-4">
-              <button
-                className=" px-4 py-2.5 bg-ca-pink rounded border border-ca-pink-shade justify-start items-center gap-2 flex"
-                onClick={() => setShowLogModal(true)}
-              >
-                <div className="text-foreground h-4 w-4 relative">
-                  {<PlusIcon />}
-                </div>
-                <div className="text-foreground text-base font-medium">
-                  Add a log
-                </div>
-              </button>
               <LogSearchFilterBar
                 filters={appliedFilters}
                 setFilters={setAppliedFilters}
                 setSearch={setSearchQuery}
+                addLogFunction={() => setShowLogModal(true)}
               />
 
               <TagDisplay tags={tags} removeTag={removeTag} />


### PR DESCRIPTION
## Move Add Log Button and Disable Save Log Button
Issue Number(s): #72

When the user hits the save log button, while the log is saving, the save button is disabled and shows a gray disabled state. Also, the Add Log Button has been moved to the Log Filter component for proper styling.

### Checklist
- [x] Requirements have been implemented
- [x] Acceptance criteria is met
- [x] Database schema [docs](https://www.notion.so/gtbitsofgood/Database-Schema-Docs-a841a38d02db4428a7cdc85dcbb8a35c?pvs=4) have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (EM) have been assigned to this PR