### PR TITLE
bug fix: bounding width and truncating long words

### DIFF
--- a/src/components/Log.jsx
+++ b/src/components/Log.jsx
@@ -2,7 +2,6 @@ import TagDisplay from "@/components/TagDisplay";
 import { useState } from "react";
 
 export default function Log({ log }) {
-  
   const [showMore, setShowMore] = useState(false);
   const createdAt = new Date(log.createdAt);
 
@@ -15,7 +14,7 @@ export default function Log({ log }) {
   ];
 
   return (
-    <div className="bg-primary-background p-4 my-4">
+    <div className="bg-primary-background p-4 my-4 w-full">
       <div className="flex justify-between">
         <div className="flex flex-col">
           <h2>{log.title}</h2>
@@ -34,8 +33,8 @@ export default function Log({ log }) {
         <TagDisplay tags={tags} removeTag={null} />
       </div>
       {log.description.length > 250 ? (
-        <div>
-          <p className="pt-4">
+        <div className="max-w-fit">
+          <p className="pt-4 break-words">
             {showMore
               ? log.description
               : log.description.substring(0, 250) + "..."}
@@ -50,7 +49,7 @@ export default function Log({ log }) {
           </div>
         </div>
       ) : (
-        <p className="pt-4">{log.description}</p>
+        <p className="min-w-fit pt-4 break-words">{log.description}</p>
       )}
     </div>
   );


### PR DESCRIPTION
## bug fix: bounding width and truncating long words
Issue Number(s): #76 

What does this PR change and why?
Ensures that log descriptions fit within the allotted log div and that the show more / less button works as intended.

### Checklist
- [X] Requirements have been implemented
- [X] Acceptance criteria is met
- [X] Database schema [docs](https://www.notion.so/gtbitsofgood/Database-Schema-Docs-a841a38d02db4428a7cdc85dcbb8a35c?pvs=4) have been updated or are not necessary
- [X] Code follows design and style guidelines
- [X] Commits follow guidelines (concise, squashed, etc)
- [X] Relevant reviewers (EM) have been assigned to this PR

### Related PRs
PR Number(s): #54 

### How To Test
In the individual dog logs tab, attempt to add a log with a description whose length is greater than 250 characters. Ensure that the text fits within the log div and that the "Show More/Less" button works!
