### PR TITLE
Create/Read API Form Endpoints

### DIFF
--- a/server/db/actions/Form.js
+++ b/server/db/actions/Form.js
@@ -28,3 +28,13 @@ export async function createForm(formData) {
 
   return form._id;
 }
+
+export async function getFormById(id) {
+  try {
+    await dbConnect();
+
+    return Form.findById(id).populate("user").populate("dog");
+  } catch (e) {
+    throw new Error("Unable to get the form at this time, please try again");
+  }
+}

--- a/server/db/actions/Form.js
+++ b/server/db/actions/Form.js
@@ -38,3 +38,13 @@ export async function getFormById(id) {
     throw new Error("Unable to get the form at this time, please try again");
   }
 }
+
+export async function getForms(filter = {}) {
+  try {
+    await dbConnect();
+  } catch (e) {
+    throw new Error("Unable to get forms at this time, please try again");
+  }
+
+  return Form.find(filter).populate("user").populate("dog");
+}

--- a/server/db/actions/Form.js
+++ b/server/db/actions/Form.js
@@ -1,0 +1,30 @@
+import dbConnect from "../dbConnect";
+import Dog from "../models/Dog";
+import User from "../models/User";
+import Form from "../models/Form";
+
+export async function createForm(formData) {
+  try {
+    await dbConnect();
+  } catch (e) {
+    throw new Error("Unable to create log at this time, please try again");
+  }
+
+  if (formData.user && !(await User.findById(formData.user))) {
+    throw new Error("User ID is not present in database");
+  }
+
+  if (formData.dog && !(await Dog.findById(formData.dog))) {
+    throw new Error("Dog ID is not present in database");
+  }
+
+  const form = new Form(formData);
+
+  try {
+    await form.save();
+  } catch (e) {
+    throw new Error(e);
+  }
+
+  return form._id;
+}

--- a/src/pages/api/forms/[id].js
+++ b/src/pages/api/forms/[id].js
@@ -1,0 +1,28 @@
+import { getFormById } from "../../../../server/db/actions/Form";
+
+export default async function handler(req, res) {
+  if (req.method == "GET") {
+    try {
+      const data = await getFormById(req.query);
+
+      if (!data) {
+        return res.status(404).send({
+          success: false,
+          error: "Unable to retrieve dog because it doesn't exist",
+        });
+      }
+
+      return res.status(200).send({
+        success: true,
+        data: data,
+      });
+    } catch (error) {
+      return res.status(500).send({ success: false, error: error.message });
+    }
+  }
+
+  return res.status(405).send({
+    success: false,
+    message: `Request method ${req.method} is not allowed`,
+  });
+}

--- a/src/pages/api/forms/[id].js
+++ b/src/pages/api/forms/[id].js
@@ -1,9 +1,17 @@
+import { Types } from "mongoose";
 import { getFormById } from "../../../../server/db/actions/Form";
 
 export default async function handler(req, res) {
   if (req.method == "GET") {
+    if (!Types.ObjectId.isValid(req.query.id)) {
+      return res.status(422).send({
+        success: false,
+        message: "Unable to get form because form id is not in valid format",
+      });
+    }
+
     try {
-      const data = await getFormById(req.query);
+      const data = await getFormById(req.query.id);
 
       if (!data) {
         return res.status(404).send({

--- a/src/pages/api/forms/index.js
+++ b/src/pages/api/forms/index.js
@@ -1,0 +1,42 @@
+import { validateForm } from "@/utils/formUtils";
+import { formSchema } from "@/utils/consts";
+import { createForm } from "../../../../server/db/actions/Form";
+
+export default async function handler(req, res) {
+  if (req.method == "POST") {
+    const { success, error, data } = formSchema.safeParse(req.body);
+
+    if (!success) {
+      return res.status(422).send({
+        success: false,
+        message: "The field " + Object.keys(error.format())[1] + " is invalid",
+      });
+    }
+
+    const results = validateForm(data.type, data.responses);
+
+    if (!results.success) {
+      return res.status(422).send(results);
+    }
+
+    return createForm(data)
+      .then((id) => {
+        return res.status(201).send({
+          success: true,
+          message: "New form successfully created!",
+          data: { _id: id },
+        });
+      })
+      .catch((error) => {
+        return res.status(500).send({
+          success: false,
+          message: error.message,
+        });
+      });
+  }
+
+  return res.status(405).json({
+    success: false,
+    message: `Request method ${req.method} is not allowed`,
+  });
+}

--- a/src/pages/api/forms/search.js
+++ b/src/pages/api/forms/search.js
@@ -1,0 +1,36 @@
+import { formSchema } from "@/utils/consts";
+import { getForms } from "../../../../server/db/actions/Form";
+
+export default async function handler(req, res) {
+  if (req.method == "POST") {
+    try {
+      const {
+        success,
+        error,
+        data: filter,
+      } = formSchema.partial().safeParse(req.body ? req.body : {});
+
+      if (!success) {
+        return res.status(422).json({
+          success: false,
+          message:
+            "The field " + Object.keys(error.format())[1] + " is invalid",
+        });
+      }
+
+      const data = await getForms(filter);
+
+      return res.status(200).send({
+        success: true,
+        data: data,
+      });
+    } catch (error) {
+      return res.status(500).send({ success: false, error: error.message });
+    }
+  }
+
+  return res.status(405).send({
+    success: false,
+    message: `Request method ${req.method} is not allowed`,
+  });
+}

--- a/src/pages/api/seed.js
+++ b/src/pages/api/seed.js
@@ -6,6 +6,9 @@ import Dog from "../../../server/db/models/Dog";
 import { createLog } from "../../../server/db/actions/Log";
 import { consts } from "@/utils/consts";
 import { createDog } from "../../../server/db/actions/Dog";
+import Form from "../../../server/db/models/Form";
+import { formMap } from "@/utils/formUtils";
+import { createForm } from "../../../server/db/actions/Form";
 
 const dogs = [];
 const users = [
@@ -309,6 +312,27 @@ const dogBreeds = [
 
 const disabilities = ["epilepsy", "mobility", "diabetes", "PTSD"];
 
+const forms = [
+  {
+    type: consts.formTypeArray[0],
+    user: "",
+    dog: "",
+    responses: [],
+  },
+  {
+    type: consts.formTypeArray[1],
+    user: "",
+    dog: "",
+    responses: [],
+  },
+  {
+    type: consts.formTypeArray[2],
+    user: "",
+    dog: "",
+    responses: [],
+  },
+];
+
 export default async function handler(req, res) {
   if (req.method === "GET") {
     await dbConnect();
@@ -316,6 +340,7 @@ export default async function handler(req, res) {
     await User.deleteMany({});
     await Log.deleteMany({});
     await Dog.deleteMany({});
+    await Form.deleteMany({});
 
     // create users
     const userIds = [];
@@ -400,6 +425,26 @@ export default async function handler(req, res) {
       logs[i].author = userIds[getRandomInt(0, userIds.length - 1)];
       await createLog(logs[i]);
     }
+
+    // create forms
+    for (let i = 0; i < forms.length; i++) {
+      forms[i].dog = dogIds[getRandomInt(0, dogIds.length - 1)];
+      forms[i].user = userIds[getRandomInt(0, userIds.length - 1)];
+
+      const formTemplate = formMap[forms[i].type];
+      for (let j = 0; j < formTemplate.length; j++) {
+        forms[i].responses.push({
+          answer:
+            formTemplate[i].choices.length > 0
+              ? formTemplate[i].choices[
+                  getRandomInt(0, formTemplate[i].choices.length - 1)
+                ]
+              : "Long answer",
+        });
+      }
+      await createForm(forms[i]);
+    }
+
     return res.send("Successfully seeded db");
   }
   return res.redirect("/");

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -188,4 +188,22 @@ const logSchema = z.object({
   }),
 });
 
-export { pages, consts, dogSchema, logSchema, userUpdateSchema };
+/**
+ * Zod object for validating request bodies for forms
+ */
+const formSchema = z.object({
+  type: z.enum(consts.formTypeArray),
+  user: z.string().refine((id) => {
+    return Types.ObjectId.isValid(id) ? new Types.ObjectId(id) : null;
+  }),
+  dog: z.string().refine((id) => {
+    return Types.ObjectId.isValid(id) ? new Types.ObjectId(id) : null;
+  }),
+  responses: z.array(
+    z.object({
+      answer: z.string(),
+    }),
+  ),
+});
+
+export { pages, consts, dogSchema, logSchema, userUpdateSchema, formSchema };

--- a/src/utils/formConsts.js
+++ b/src/utils/formConsts.js
@@ -1,0 +1,400 @@
+const MONTHLY_PLACED_FORM = [
+  {
+    question: "Work or school schedule",
+    choices: ["Full-Time", "Part-Time", "N/a"],
+  },
+  {
+    question: "How easy has it been to get your dog into the car?",
+    choices: ["Very Easy", "Fairly Easy", "Difficult", "Very Difficult"],
+  },
+  {
+    question: "How comfortable was your dog in the car?",
+    choices: [
+      "Totally comfortable",
+      "fairly comfortable",
+      "stayed curled on the floorboard",
+      "paced the whole time",
+    ],
+  },
+  {
+    question: "How easy has it been to get your dog out of the car?",
+    choices: ["Very easy", "Fairly easy", "Difficult", "Very difficult"],
+  },
+  {
+    question: "Did you teach your dog anything new? If yes, please describe.",
+    choices: [],
+  },
+  {
+    question: "Is there anything you would like to teach your dog?",
+    choices: [],
+  },
+  {
+    question: "Any veterinary care given? If yes, please describe.",
+    choices: [],
+  },
+  {
+    question: "How often did your dog bark at home?",
+    choices: ["None", "A few times", "Every day", "Multiple times every day"],
+  },
+  {
+    question: "How often did your dog bark at work or school?",
+    choices: ["None", "A few times", "Every day", "Multiple times every day"],
+  },
+  {
+    question:
+      "Did your dog have any accidents in the house? If yes, please give details.",
+    choices: [],
+  },
+  {
+    question:
+      "Did your dog have any accidents in public? If yes, please give details.",
+    choices: [],
+  },
+  {
+    question: "Overall, how comfortable was your dog when you were out?",
+    choices: ["Bold", "Comfortable", "Somewhat hesitant", "Hesitant"],
+  },
+  {
+    question:
+      "Was your dog startled or upset by any sounds? If yes, please explain in detail.",
+    choices: [],
+  },
+  {
+    question:
+      "Was your dog startled or upset by any sights (including people or other dogs)? If yes, please explain in detail.",
+    choices: [],
+  },
+  {
+    question: "How often were you able to play with your dog?",
+    choices: [],
+  },
+  {
+    question: "Did your dog play with any other dogs?",
+    choices: [],
+  },
+  {
+    question: "Is there anything else you’d like us to know?",
+    choices: [],
+  },
+  {
+    question: "Is there anything you’d like to discuss with us?",
+    choices: [],
+  },
+];
+
+// How comfortable was your dog in the car?
+const MONTHLY_UNPLACED_FORM = [
+  {
+    question: "Does the dog show safe haven effect with instructor?",
+    choices: ["Yes", "No"],
+  },
+  {
+    question: "Does the dog show secure base effect with instructor?",
+    choices: ["Yes", "No"],
+  },
+  {
+    question: "Does the dog show proximity maintenance with instructor?",
+    choices: ["Yes", "No"],
+  },
+  {
+    question:
+      "Does the dog show separation distress/reunion joy with instructor?",
+    choices: ["Yes", "No"],
+  },
+  {
+    question: "Can the dog answer yes or no questions?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Can the dog answer other binary questions?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Can the dog reason by exclusion?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question:
+      "Does the dog synchronize with the activity level of his instructor?",
+    choices: ["Always", "Sometimes", "Never"],
+  },
+  {
+    question:
+      "Does the dog understand how to move objects with his mouth, nose, and paws?",
+    choices: ["Yes", "Working on it", "No"],
+  },
+  {
+    question: "Does the dog communicate information to his instructor?",
+    choices: ["Yes", "Sometimes", "Not yet"],
+  },
+  {
+    question: "Does the dog respond to his instructor’s body language?",
+    choices: ["Yes", "Sometimes", "Not yet"],
+  },
+  {
+    question: "Does the dog respond to his instructor’s spoken directives?",
+    choices: ["Yes", "Sometimes", "Not yet"],
+  },
+  {
+    question: "Does the dog walk calmly on a loose leash?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog understand the concept of being gentle when asked?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question:
+      "Does the dog gently take food from between instructor’s fingertips?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog go better hurry on leash?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog freeze and maintain position until touched?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog pause before crossing thresholds?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog respond to 'ick'?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog copy actions using 'like me'?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog retrieve to hand or lap?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog tug?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog do light switches?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog press buttons?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog recognize the pre-ictal odor?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog recognize the smell of low blood sugar?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Does the dog recognize the smell of high blood sugar?",
+    choices: ["Always", "Working on it", "Doesn't know"],
+  },
+  {
+    question: "Is the dog startled by loud noises?",
+    choices: ["Always", "Sometimes", "Never"],
+  },
+  {
+    question: "Is the dog startled by strange sights?",
+    choices: ["Always", "Sometimes", "Never"],
+  },
+  {
+    question: "Does the dog play well with other dogs?",
+    choices: ["Always", "Usually", "Not really"],
+  },
+  {
+    question: "How easy is it to put the dog’s harness on?",
+    choices: ["Very easy", "Easy", "Somewhat difficult", "Really difficult"],
+  },
+  {
+    question:
+      "Does the dog hold his end of the We Leash when asked to do so? If yes, what attachments will he hold?",
+    choices: [
+      "Handle with bone",
+      "Plain handle",
+      "Binkie",
+      "Toy (place for notes)",
+    ],
+  },
+  {
+    question: "How easy is it to get the dog into a car?",
+    choices: ["Very easy", "Fairly easy", "Difficult", "Very difficult"],
+  },
+  {
+    question: "How comfortable is the dog in a car?",
+    choices: [
+      "Totally comfortable",
+      "Fairly comfortable",
+      "Stayed curled on the floorboard",
+      "Paced the whole time",
+    ],
+  },
+  {
+    question: "How easy is it to get the dog out of a car?",
+    choices: ["Very easy", "Fairly easy", "Difficult", "Very difficult"],
+  },
+  {
+    question:
+      "Is the dog on any medications? If so, please give the name and dosage.",
+    choices: [],
+  },
+  {
+    question: "Affectionate to Fearful Scale (with people):",
+    choices: [
+      "Calmly affectionate",
+      "Excitedly affectionate",
+      "Somewhat aloof",
+      "Aloof",
+      "Fearful",
+    ],
+  },
+  {
+    question: "Affectionate to Fearful with New People",
+    choices: [
+      "Calmly affectionate",
+      "Excitedly affectionate",
+      "Somewhat aloof",
+      "Aloof",
+      "Fearful",
+    ],
+  },
+  {
+    question: "Bold to Hesitant in familiar situations scale",
+    choices: ["Bold", "Comfortable", "Somewhat hesitant", "Hesitant"],
+  },
+  {
+    question: "Bold to Shy in New Situations",
+    choices: ["Bold", "Comfortable", "Somewhat hesitant", "Hesitant"],
+  },
+];
+
+const VOLUNTEER_FORM = [
+  {
+    question: "How many times have you worked with this dog previously?",
+    choices: ["None", "Once", "2-3 times", "4-5 times", "6 or more times"],
+  },
+  {
+    question: "Did you give the dog a bath?",
+    choices: ["Yes", "No"],
+  },
+  {
+    question: "How hard was it to get the dog into the tub?",
+    choices: [
+      "Easy",
+      "Somewhat difficult",
+      "Different",
+      "Very difficult",
+      "N/a",
+    ],
+  },
+  {
+    question: "How comfortable was the dog in the bathtub?",
+    choices: [
+      "Comfortable",
+      "Wiggling but okay",
+      "Tried to get out the whole time",
+      "N/a",
+    ],
+  },
+  {
+    question:
+      "Did you use a forced air dryer? If yes, how comfortable was the dog with the dryer?",
+    choices: [
+      "Totally comfortable",
+      "Fairly comfortable",
+      "Didn’t like it",
+      "Was afraid of it",
+    ],
+  },
+  {
+    question:
+      "Did you use a handheld hair dryer? If yes, how comfortable was the dog with the dryer?",
+    choices: [
+      "Totally comfortable",
+      "Fairly comfortable",
+      "Didn’t like it",
+      "Was afraid of it",
+    ],
+  },
+  {
+    question: "How easy was it to put the dog’s harness on?",
+    choices: ["Very easy", "Easy", "Somewhat difficult", "Really difficult"],
+  },
+  {
+    question:
+      "Did the dog hold his end of the We Leash when asked to do so? If yes, what attachment did you use?",
+    choices: [
+      "Handle with bone",
+      "Plain handle",
+      "Binkie",
+      "Toy (place for notes)",
+    ],
+  },
+  {
+    question: "How easy was it to get your dog into the car?",
+    choices: ["Very easy", "Fairly easy", "Difficult", "Very difficult"],
+  },
+  {
+    question: "How comfortable was your dog in the car?",
+    choices: [
+      "Totally comfortable",
+      "Fairly comfortable",
+      "Stayed curled on the floorboard",
+      "Paced the whole time",
+    ],
+  },
+  {
+    question: "How easy was it to get your dog out of the car?",
+    choices: ["Very easy", "Fairly easy", "Difficult", "Very difficult"],
+  },
+  {
+    question: "Did you take the dog on a home visit?",
+    choices: ["Yes", "No"],
+  },
+  {
+    question: "How long did the dog stay?",
+    choices: [],
+  },
+  {
+    question: "Had this dog been to your home previously?",
+    choices: ["Once", "2-3 times", "4-5 times", "6 or more times"],
+  },
+  {
+    question: "How comfortable was the dog in your home?",
+    choices: ["Bold", "Comfortable", "Somewhat hesitant", "Hesitant"],
+  },
+  {
+    question: "How many times did the dog urinate in the house?",
+    choices: ["(Place for notes)"],
+  },
+  {
+    question: "How many times did the dog defecate in the house?",
+    choices: ["(Place for notes)"],
+  },
+  {
+    question: "Outings: Please list everywhere you took the dog",
+    choices: [],
+  },
+  {
+    question: "Overall, how comfortable was the dog on your outings?",
+    choices: ["Bold", "Comfortable", "Somewhat hesitant", "Hesitant"],
+  },
+  {
+    question:
+      "Was your dog startled or upset by any sounds? If yes, please explain in detail.",
+    choices: [],
+  },
+  {
+    question:
+      "Was your dog startled or upset by any sights (including people or other dogs)? If yes, please explain in detail.",
+    choices: [],
+  },
+];
+
+export { MONTHLY_PLACED_FORM, MONTHLY_UNPLACED_FORM, VOLUNTEER_FORM };

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -1,0 +1,48 @@
+import {
+  MONTHLY_PLACED_FORM,
+  MONTHLY_UNPLACED_FORM,
+  VOLUNTEER_FORM,
+} from "./formConsts";
+
+/**
+ * Maps each form type to the form
+ */
+const formMap = {
+  MonthlyPlaced: MONTHLY_PLACED_FORM,
+  MonthlyUnplaced: MONTHLY_UNPLACED_FORM,
+  VolunteerInteraction: VOLUNTEER_FORM,
+};
+
+/**
+ * Validates each array element in the responses array
+ * @param {string} type Type of form, should be one of consts.formTypeArray options
+ * @param {string[]} responses Array of objects with key of "answer" and value of the string response
+ * @returns Object { success: Boolean, message: String | undefined }
+ */
+const validateForm = (type, responses) => {
+  const formTemplate = formMap[type];
+
+  if (responses.length != formTemplate.length) {
+    return {
+      success: false,
+      message: `The responses array is not the correct length. Expected length to be ${formTemplate.length}, was ${responses.length}`,
+    };
+  }
+
+  for (let i = 0; i < responses.length; i++) {
+    let choicesArray = formTemplate[i]["choices"];
+    if (choicesArray.length) {
+      if (!choicesArray.includes(responses[i]["answer"])) {
+        return {
+          success: false,
+          message: `Array element invalid at index ${i}. Expected one of [
+            ${choicesArray.join(", ")}], was ${responses[i]["answer"]}`,
+        };
+      }
+    }
+  }
+
+  return { success: true };
+};
+
+export { validateForm };

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -45,4 +45,4 @@ const validateForm = (type, responses) => {
   return { success: true };
 };
 
-export { validateForm };
+export { validateForm, formMap };


### PR DESCRIPTION
## Create/Read API Form Endpoints
Issue Number(s): #56

This PR adds API endpoints for creating forms, getting forms by ID, and searching for forms. The form Zod schema has been added as well and a helper function to validate array elements for the format of specific elements.

### Checklist
- [x] Requirements have been implemented
- [x] Acceptance criteria is met
- [x] Database schema [docs](https://www.notion.so/gtbitsofgood/Database-Schema-Docs-a841a38d02db4428a7cdc85dcbb8a35c?pvs=4) have been updated or are not necessary
- [x] Code follows design and style guidelines
- [x] Commits follow guidelines (concise, squashed, etc)
- [x] Relevant reviewers (EM) have been assigned to this PR

### How To Test
Sample MonthlyPlaced request body for creating a form:
```
{
    "type": "MonthlyPlaced",
    "user": "65355c9ffa9f201f083aff0e",
    "dog": "65355ca0fa9f201f083aff25",
    "responses": [
        {"answer": "Part-Time"},
        {"answer": "Fairly Easy"},
        {"answer": "Totally comfortable"},
        {"answer": "Fairly easy"},
        {"answer": "No"},
        {"answer": "No"},
        {"answer": "No"},
        {"answer": "A few times"},
        {"answer": "A few times"},
        {"answer": "No"},
        {"answer": "No"},
        {"answer": "Comfortable"},
        {"answer": "No"},
        {"answer": "No"},
        {"answer": "No"},
        {"answer": "No"},
        {"answer": "No"},
        {"answer": "No"}
    ]
}
```