### PR TITLE
CSS Styles for Components

### DIFF
--- a/src/components/Log/LogModal.jsx
+++ b/src/components/Log/LogModal.jsx
@@ -293,23 +293,21 @@ export default function LogModal({ dogId, userId, onClose, onSubmit }) {
         <div className="flex flex-col-reverse sm:flex-row justify-end gap-[2vw]">
           <button
             onClick={() => onClose()}
-            className="w-full sm:w-32 h-10 px-4 py-2.5 bg-secondary-gray rounded border border-primary-gray justify-center items-center gap-2 flex"
+            className="button-base secondary-button flex w-full sm:w-32 h-10"
           >
-            <div className="text-primary-text text-sm font-medium">Cancel</div>
+            <div className="secondary-button-text">Cancel</div>
           </button>
           <button
             onClick={() => saveLog(logData)}
             disabled={saving}
-            className={`w-full sm:w-32 h-10 px-4 py-2.5 ${
+            className={`flex w-full sm:w-32 h-10 button-base ${
               saving
-                ? " bg-primary-gray border-tertiary-gray "
-                : " bg-ca-pink border-ca-pink-shade "
-            }  rounded border justify-center items-center gap-2 flex`}
+                ? " disabled-button"
+                : " primary-button"
+            }`}
           >
             <div
-              className={`${
-                saving ? "text-tertiary-gray " : "text-foreground "
-              } text-base font-medium`}
+              className={`${ saving ? "disabled-button-text" : "primary-button-text" }`}
             >
               Save
             </div>

--- a/src/components/Log/LogModal.jsx
+++ b/src/components/Log/LogModal.jsx
@@ -102,20 +102,18 @@ export default function LogModal({ dogId, userId, onClose, onSubmit }) {
       >
         {/* TODO add behavior for dragging downwards to close the modal on mobile */}
         <div className="sm:hidden w-8 h-1 opacity-40 bg-zinc-500 rounded-[100px] mx-auto mb-[12px]" />
-        <h1 className="mb-[3vh]"> Add a log</h1>
-        <h2 className="h-[5vh]">
+        <h1 className="mb-6"> Add a log</h1>
+        <h2 className="h-10 align-middle">
           Title<span className="text-error-red">*</span>
         </h2>
-        <div className="mb-[3vh]">
+        <div className="mb-6">
           <input
             value={logData.title}
             onChange={(event) => {
               setLogData({ ...logData, title: event.target.value });
               setErrors({ ...errors, title: false });
             }}
-            className={`rounded bg-foreground border ${
-              errors.title ? "border-error-red" : "border-primary-gray"
-            } focus:border-primary-gray focus:border text-secondary-text text-lg font-normal w-full h-11 px-4 py-2.5`}
+            className={`text-input textbox-base ${ errors.title ? "textbox-error" : "textbox-border" } w-full`}
           ></input>
           {errors.title ? (
             <div className="flex items-center gap-[5px] text-black text-lg font-normal">
@@ -127,7 +125,7 @@ export default function LogModal({ dogId, userId, onClose, onSubmit }) {
           ) : null}
         </div>
 
-        <h2 className="h-[5vh]">
+        <h2 className="h-10 align-middle">
           Tags<span className="text-error-red">*</span>
         </h2>
         <div className="flex flex-col sm:flex-row gap-[3vw]">
@@ -266,19 +264,17 @@ export default function LogModal({ dogId, userId, onClose, onSubmit }) {
           </div>
         </div>
 
-        <h2 className="h-[5vh]">
+        <h2 className="h-10 align-middle">
           Log Description<span className="text-error-red">*</span>
         </h2>
-        <div className="mb-[3vh]">
+        <div className="mb-6">
           <textarea
             value={logData.description}
             onChange={(event) => {
               setLogData({ ...logData, description: event.target.value });
               setErrors({ ...errors, description: false });
             }}
-            className={`rounded bg-foreground border ${
-              errors.description ? "border-error-red" : "border-primary-gray"
-            } text-secondary-text text-lg font-normal w-full h-[25vh] min-h-[44px] max-h-[25vh] resize-none sm:resize-y px-4 py-2.5`}
+            className={`text-area textbox-base ${ errors.description ? "textbox-error" : "textbox-border" } w-full`}
           ></textarea>
           {errors.description ? (
             <div className="flex items-center gap-[5px] text-black text-lg font-normal">

--- a/src/components/Log/LogSearchFilterBar.jsx
+++ b/src/components/Log/LogSearchFilterBar.jsx
@@ -12,14 +12,14 @@ export default function LogSearchFilterBar({ filters, setFilters, setSearch, add
           </div>
           <input
             type="search"
-            className="w-full h-full rounded bg-foregrund border border-neutral-300 text-neutral-700 text-lg p-2.5 pl-10 font-normal"
+            className="w-full h-full rounded bg-foreground border border-neutral-300 text-neutral-700 text-lg p-2.5 pl-10 font-normal"
             placeholder="Search Logs..."
             onChange={(e) => setSearch(e.target.value)}
           />
         </div>
-        <button type="button" onClick={() => addLogFunction()} className=" px-4 py-2.5 bg-ca-pink rounded border border-ca-pink-shade justify-start items-center gap-2 flex">
-          <div className="text-foreground h-4 w-4 relative">{<PlusIcon />}</div>
-          <div className="text-foreground text-base font-medium">Add a log</div>
+        <button type="button" onClick={() => addLogFunction()} className="button-base primary-button flex gap-2">
+          <div className="primary-button-plus-icon">{<PlusIcon />}</div>
+          <div className="primary-button-text">Add a log</div>
         </button>
       </div>
       <div className="flex flex-row items-center gap-4">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,7 +5,9 @@
 @tailwind components;
 @tailwind utilities;
 
-input[type='text']:focus { box-shadow: none; }
+input[type="text"]:focus {
+  box-shadow: none;
+}
 
 @layer base {
   * {
@@ -44,5 +46,42 @@ input[type='text']:focus { box-shadow: none; }
 
   .modal-shadow-mobile {
     box-shadow: 2px -2px 3px 0 rgba(0, 0, 0, 0.3);
+  }
+
+  .button-base {
+    @apply rounded border px-4 py-2.5 items-center justify-center;
+  }
+
+  .primary-button {
+    @apply bg-ca-pink border-ca-pink-shade;
+  }
+
+  .secondary-button {
+    @apply bg-foreground border-primary-gray;
+  }
+
+  .tertiary-button {
+    @apply bg-secondary-gray border-primary-gray;
+  }
+
+  .disabled-button {
+    @apply bg-primary-gray border-tertiary-gray;
+  }
+
+  .primary-button-text {
+    @apply text-foreground text-base font-medium;
+  }
+
+  .primary-button-plus-icon {
+    @apply text-foreground h-4 w-4 relative;
+  }
+
+  /* Also used for tertiary button text */
+  .secondary-button-text {
+    @apply text-primary-text text-base font-medium;
+  }
+
+  .disabled-button-text {
+    @apply text-tertiary-gray text-base font-medium;
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -84,4 +84,24 @@ input[type="text"]:focus {
   .disabled-button-text {
     @apply text-tertiary-gray text-base font-medium;
   }
+
+  .textbox-base {
+    @apply px-4 py-2.5 bg-foreground rounded border text-secondary-text text-lg font-normal focus:border-primary-text focus:ring-0;
+  }
+
+  .textbox-border {
+    @apply border-primary-gray;
+  }
+
+  .textbox-error {
+    @apply border-error-red;
+  }
+
+  .text-input {
+    @apply h-11;
+  }
+
+  .text-area {
+    @apply resize-none sm:resize-y min-h-[44px] max-h-[1000px] h-[220px];
+  }
 }


### PR DESCRIPTION
## CSS Styles for Components

For frequently used components like buttons, text inputs, and text areas, CSS styles have been added to keep styles consistent for these components accross the codebase. This also makes it easier for frontend development and increases readability. Each type of element has a base such as `button-base` with the styles for all buttons, then each type of component has another selector to pair with the same such as `primary-button` or `secondary-button`.

Spacing within the Add Log modal has been changed as well from relative to absolute since the relative spacing did not make sense for smaller screens since the modal has scrolling behavior within it.

### Checklist

- [x] Requirements have been implemented
- [x] Acceptance criteria is met
- [x] Database schema [docs](https://www.notion.so/gtbitsofgood/Database-Schema-Docs-a841a38d02db4428a7cdc85dcbb8a35c?pvs=4) have been updated or are not necessary
- [x] Relevant reviewers (EM) have been assigned to this PR
