### PR TITLE
Update User model + users page

### DIFF
--- a/server/db/models/User.js
+++ b/server/db/models/User.js
@@ -26,6 +26,16 @@ const UserSchema = new Schema({
   passwordHash: {
     type: String,
   },
+  isActive: {
+    type: Boolean,
+    default: true,
+    required: true,
+  },
+  acceptedInvite: {
+    type: Boolean,
+    default: false,
+    required: true,
+  },
 });
 
 export default mongoose.models?.User ?? mongoose.model("User", UserSchema);

--- a/src/pages/account.jsx
+++ b/src/pages/account.jsx
@@ -185,8 +185,9 @@ export default function Account() {
   );
 
   function deactivateModal() {
-    let body = {};
-    body.role = consts.userRoleArray[2];
+    let body = {
+      isActive: false,
+    };
     fetch("/api/users/" + userId, {
       method: "PATCH",
       headers: {

--- a/src/pages/api/users/[id].js
+++ b/src/pages/api/users/[id].js
@@ -47,8 +47,12 @@ export default async function handler(req, res) {
       .partial()
       .strict()
       .refine(
-        (data) => data.name || data.role,
-        "Must update either name or role",
+        (data) =>
+          data.name ||
+          data.role ||
+          data.hasOwnProperty("isActive") ||
+          data.hasOwnProperty("acceptedInvite"),
+        "Must update either name, role, status, or invite status.",
       )
       .safeParse(req.body);
 

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -23,8 +23,12 @@ const consts = {
   concernArray: ["None", "Moderate", "High"],
   locationArray: ["Facility 1", "Facility 2", "Placed"],
   roleArray: ["Service", "Companion"],
-  userRoleArray: ["Admin", "User", "Inactive"],
-  userAccessArray: ["Admin", "User"],
+  userRoleArray: ["Manager", "Admin", "User"],
+  userAccess: {
+    Manager: "Manager",
+    Admin: "Admin",
+    User: "User",
+  },
   leashArray: ["Leashed", "Off-leash"],
   relationshipArray: [
     "Sibling",
@@ -321,6 +325,8 @@ const computeDefaultValues = (dog) => {
 const userUpdateSchema = z.object({
   name: z.string(),
   role: z.enum(consts.userRoleArray),
+  isActive: z.boolean(),
+  acceptedInvite: z.boolean(),
 });
 
 const userRegistrationSchema = z.object({


### PR DESCRIPTION
## Updates to User Model & User management page

What does this PR change and why?
- adds `isActive` and `acceptedInvite` to the User model to decouple status from role and allow for invites
- change user management role selection and active toggle to work with `isActive` attribute

### Checklist

- [x] Database schema [docs](https://www.notion.so/gtbitsofgood/Database-Schema-Docs-fd377ded10b54890b65fd99025488cee?pvs=4) have been updated or are not necessary

### Critical Changes

- Database change / migration to run
- Breaking API change
