### PR TITLE
Fix "Show more" button triggering form submission

### DIFF
--- a/src/components/Log/Log.jsx
+++ b/src/components/Log/Log.jsx
@@ -133,6 +133,7 @@ export default function Log({ log, user, onEdit, onDelete }) {
             <button
               className="font-bold"
               onClick={() => setShowMore(!showMore)}
+              type="button"
             >
               {showMore ? "Show Less" : "Show More"}
             </button>


### PR DESCRIPTION
## Fix "Show more" button triggering form submission

Issue Number(s): #186 

What does this PR change and why?
Add `type="button"` to the Show more button in the `Log.jsx` component. This ensures this button does not submit the edit dog form. 